### PR TITLE
Console script to call hal4000 directly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,12 @@ setup(
 
     setup_requires=[],
     tests_require=[],
-    
-    license="",  
+
+    entry_points={
+        'console_scripts': ['hal4000=storm_control.hal4000.__main__:main'],
+    },
+
+    license="",
     keywords='storm,microscopy',
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/storm_control/hal4000/__main__.py
+++ b/storm_control/hal4000/__main__.py
@@ -1,0 +1,5 @@
+from .hal4000 import main
+
+
+if __name__ == "__main__":
+    main()

--- a/storm_control/hal4000/hal4000.py
+++ b/storm_control/hal4000/hal4000.py
@@ -718,7 +718,7 @@ class HalCore(QtCore.QObject):
             self.queued_messages_timer.start()
 
 
-if (__name__ == "__main__"):
+def main():
 
     # Use both so that we can pass sys.argv to QApplication.
     import argparse
@@ -763,6 +763,8 @@ if (__name__ == "__main__"):
     
     app.exec_()
 
+if (__name__ == "__main__"):
+    main()
 
 #
 # The MIT License


### PR DESCRIPTION
This will introduce a command to call hal4000 directly from the terminal. Tested in Linux.